### PR TITLE
ROS2環境のプルリクエスト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# for ROS2
+build/
+install/
+log/

--- a/src/robot_integration/CMakeLists.txt
+++ b/src/robot_integration/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.8)
+project(robot_integration)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/robot_integration/package.xml
+++ b/src/robot_integration/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robot_integration</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="eevee@todo.todo">eevee</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
ROS2 Gazeboの環境のプルリクエストをお送りします。
現状は、以下のリクエストになります。
・ROS2の使用パッケージのためのsrcフォルダの作成
・.gitignoreファイルの作成（ビルド関連ファイルを無視する）

これらを動かすためには、`ubuntu22.04`, `ROS Humble`の環境が必要です。
また、ビルド (`colcon build --symlink-install`) をすることでCleanKのフォルダ上にビルド関連ファイルが生成されます。

こちらのリポジトリへの反映がうまくいっておらず、まだ作業が途中なので引き続きプルリクエストさせていただきます！